### PR TITLE
Add functionality to read all messages in queue

### DIFF
--- a/UnityProject/Assets/Ardity/Scripts/SerialController.cs
+++ b/UnityProject/Assets/Ardity/Scripts/SerialController.cs
@@ -48,7 +48,8 @@ public class SerialController : MonoBehaviour
              "newest messages from the port.")]
     public bool dropOldMessage;
 
-    [Tooltip("Read all unread messages in the queue during every Update loop.")]
+    [Tooltip("Read all unread messages in the queue during every Update loop. " +
+             "Only used when \"Message Listener\" is provided.")]
     public bool readAllMessages;
 
     // Constants used to mark the start and end of a connection. There is no

--- a/UnityProject/Assets/Ardity/Scripts/SerialController.cs
+++ b/UnityProject/Assets/Ardity/Scripts/SerialController.cs
@@ -48,6 +48,9 @@ public class SerialController : MonoBehaviour
              "newest messages from the port.")]
     public bool dropOldMessage;
 
+    [Tooltip("Read all unread messages in the queue during every Update loop.")]
+    public bool readAllMessages;
+
     // Constants used to mark the start and end of a connection. There is no
     // way you can generate clashing messages from your serial device, as I
     // compare the references of these strings, no their contents. So if you
@@ -106,10 +109,8 @@ public class SerialController : MonoBehaviour
     }
 
     // ------------------------------------------------------------------------
-    // Polls messages from the queue that the SerialThread object keeps. Once a
-    // message has been polled it is removed from the queue. There are some
-    // special messages that mark the start/end of the communication with the
-    // device.
+    // Calls message polling every frame. Does nothing when message listener
+    // is not provided.
     // ------------------------------------------------------------------------
     void Update()
     {
@@ -118,6 +119,23 @@ public class SerialController : MonoBehaviour
         if (messageListener == null)
             return;
 
+        // If the user prefers to read all messages, then enter a loop
+        // and read messages until the queue is empty
+        if (readAllMessages)
+            while (serialThread.InputQueueCount() > 0)
+                ReadSerialMessageToMessageListener();
+        else
+            ReadSerialMessageToMessageListener();
+    }
+
+    // ------------------------------------------------------------------------
+    // Polls messages from the queue that the SerialThread object keeps. Once a
+    // message has been polled it is removed from the queue. There are some
+    // special messages that mark the start/end of the communication with the
+    // device.
+    // ------------------------------------------------------------------------
+    private void ReadSerialMessageToMessageListener()
+    {
         // Read the next message from the queue
         string message = (string) serialThread.ReadMessage();
         if (message == null)

--- a/UnityProject/Assets/Ardity/Scripts/Threads/AbstractSerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Threads/AbstractSerialThread.cs
@@ -109,6 +109,18 @@ public abstract class AbstractSerialThread
     }
 
     // ------------------------------------------------------------------------
+    // Returns number of messages in the input queue.
+    // It returns 0 if queue is not initialized.
+    // ------------------------------------------------------------------------
+    public int InputQueueCount()
+    {
+        if (inputQueue == null)
+            return 0;
+
+        return inputQueue.Count;
+    }
+
+    // ------------------------------------------------------------------------
     // Schedules a message to be sent. It writes the message to the
     // output queue, later the method 'RunOnce' reads this queue and sends
     // the message to the serial device.


### PR DESCRIPTION
Hello! Lately I was using the plugin and had a need to read all the messages in the queue every frame. The game was running at about 60FPS and I was getting 100 messages per second.

With smaller buffer size I was dropping messages (which was not acceptable for this specific use case), with bigger buffer size it introduced delay and still dropped messages.

Currently reading all messages is only possible without Message Listener (by reading messages until they're null). This PR adds functionality to read all messages to the Message Listener.