### PR TITLE
Add DTR & RTS fields to SerialController and fix the minor issue of missing package.json.meta

### DIFF
--- a/UnityProject/Assets/Ardity/Scripts/Runtime/SerialController.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/SerialController.cs
@@ -52,6 +52,9 @@ public class SerialController : MonoBehaviour
              "Only used when \"Message Listener\" is provided.")]
     public bool readAllMessages;
 
+    public bool dtrEnable;
+    public bool rtsEnable;
+
     // Constants used to mark the start and end of a connection. There is no
     // way you can generate clashing messages from your serial device, as I
     // compare the references of these strings, no their contents. So if you
@@ -76,7 +79,9 @@ public class SerialController : MonoBehaviour
                                              baudRate,
                                              reconnectionDelay,
                                              maxUnreadMessages,
-                                             dropOldMessage);
+                                             dropOldMessage,
+                                             dtrEnable,
+                                             rtsEnable);
         thread = new Thread(new ThreadStart(serialThread.RunForever));
         thread.Start();
     }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/SerialControllerCustomDelimiter.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/SerialControllerCustomDelimiter.cs
@@ -44,6 +44,9 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
              "message and the beginning of the next.")]
     public byte separator = 90;
 
+    public bool dtrEnable;
+    public bool rtsEnable;
+
     // Internal reference to the Thread and the object that runs in it.
     protected Thread thread;
     protected SerialThreadBinaryDelimited serialThread;
@@ -61,7 +64,9 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
                                                        reconnectionDelay,
                                                        maxUnreadMessages,
                                                        separator,
-                                                       dropOldMessage);
+                                                       dropOldMessage,
+                                                       dtrEnable,
+                                                       rtsEnable);
         thread = new Thread(new ThreadStart(serialThread.RunForever));
         thread.Start();
     }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/AbstractSerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/AbstractSerialThread.cs
@@ -56,6 +56,9 @@ public abstract class AbstractSerialThread
     // When the queue is full, prefer dropping the message in the queue instead of the new message
     private bool dropOldMessage;
 
+    private bool dtrEnable = false;
+    private bool rtsEnable = false;
+
 
     /**************************************************************************
      * Methods intended to be invoked from the Unity thread.
@@ -70,7 +73,9 @@ public abstract class AbstractSerialThread
                                 int delayBeforeReconnecting,
                                 int maxUnreadMessages,
                                 bool enqueueStatusMessages,
-                                bool dropOldMessage)
+                                bool dropOldMessage,
+                                bool dtrEnable,
+                                bool rtsEnable)
     {
         this.portName = portName;
         this.baudRate = baudRate;
@@ -78,6 +83,8 @@ public abstract class AbstractSerialThread
         this.maxUnreadMessages = maxUnreadMessages;
         this.enqueueStatusMessages = enqueueStatusMessages;
         this.dropOldMessage = dropOldMessage;
+        this.dtrEnable = dtrEnable;
+        this.rtsEnable = rtsEnable;
 
         inputQueue = Queue.Synchronized(new Queue());
         outputQueue = Queue.Synchronized(new Queue());
@@ -205,8 +212,8 @@ public abstract class AbstractSerialThread
         serialPort = new SerialPort(portName, baudRate);
         serialPort.ReadTimeout = readTimeout;
         serialPort.WriteTimeout = writeTimeout;
-        // serialPort.DtrEnable = true;
-        // serialPort.RtsEnable = true;
+        serialPort.DtrEnable = dtrEnable;
+        serialPort.RtsEnable = rtsEnable;
         serialPort.Open();
 
         if (enqueueStatusMessages)

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThread.cs
@@ -26,8 +26,10 @@ public class SerialThread : SerialThreadLines
                         int baudRate,
                         int delayBeforeReconnecting,
                         int maxUnreadMessages,
-                        bool dropOldMessage)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, dropOldMessage)
+                        bool dropOldMessage,
+                        bool dtrEnable,
+                        bool rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, dropOldMessage, dtrEnable, rtsEnable)
     {
     }
 }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadCustomDelimiter.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadCustomDelimiter.cs
@@ -32,8 +32,10 @@ public class SerialThreadBinaryDelimited : AbstractSerialThread
                                        int delayBeforeReconnecting,
                                        int maxUnreadMessages,
                                        byte separator,
-                                       bool dropOldMessage)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, false, dropOldMessage)
+                                       bool dropOldMessage,
+                                       bool dtrEnable,
+                                       bool rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, false, dropOldMessage, dtrEnable, rtsEnable)
     {
         this.separator = separator;
     }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadLines.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadLines.cs
@@ -25,8 +25,10 @@ public class SerialThreadLines : AbstractSerialThread
                              int baudRate,
                              int delayBeforeReconnecting,
                              int maxUnreadMessages,
-                             bool dropOldMessage)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, true, dropOldMessage)
+                             bool dropOldMessage,
+                             bool dtrEnable,
+                             bool rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, true, dropOldMessage, dtrEnable, rtsEnable)
     {
     }
 

--- a/UnityProject/Assets/Ardity/package.json.meta
+++ b/UnityProject/Assets/Ardity/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3927c04c7d89ac54dba2bd9a02430246
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi everyone,

Some students have expressed their desire to directly control DTS and RTS in the SerialController Inspector. Therefore, I have added variables to control DTS and RTS in SerialController, SerialControllerCustomDelimiter, and other related class. This update will make Ardity more user-friendly, especially for developing the USB version of the Parallax RFID Reader.

![2024051502-hKsBK2xZue](https://github.com/dwilches/Ardity/assets/10691716/078966ad-989a-4685-9564-08c656c88e85)

Additionally, I recently discovered a minor error regarding a missing package.json.meta file. While this error doesn't affect usage, it's still a good idea to fix it.

![image](https://github.com/dwilches/Ardity/assets/10691716/aa216829-eff8-40b4-b50a-96b4ce1bdc2e)

Changes:

Add DtrEnable and RtsEnable field to SerialController 0eb73eb
Create package.json.meta 7a9796c

Testing:

I've tested the changes on my local machine and they seem to be working as expected. I would appreciate it if you could take a look and let me know if you have any feedback.

Thanks,
Ted