### PR TITLE
Implement Clear Queue feature and Ignore Message Drop field

### DIFF
--- a/UnityProject/Assets/Ardity/Scripts/Runtime/SerialController.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/SerialController.cs
@@ -48,6 +48,8 @@ public class SerialController : MonoBehaviour
              "newest messages from the port.")]
     public bool dropOldMessage;
 
+    public bool ignoreDroppedMessages;
+
     [Tooltip("Read all unread messages in the queue during every Update loop. " +
              "Only used when \"Message Listener\" is provided.")]
     public bool readAllMessages;
@@ -80,6 +82,7 @@ public class SerialController : MonoBehaviour
                                              reconnectionDelay,
                                              maxUnreadMessages,
                                              dropOldMessage,
+                                             ignoreDroppedMessages,
                                              dtrEnable,
                                              rtsEnable);
         thread = new Thread(new ThreadStart(serialThread.RunForever));
@@ -166,6 +169,10 @@ public class SerialController : MonoBehaviour
         return (string) serialThread.ReadMessage();
     }
 
+    public void ClearQueue()
+    {
+        serialThread.ClearQueue();
+    }
     // ------------------------------------------------------------------------
     // Puts a message in the outgoing queue. The thread object will send the
     // message to the serial device when it considers it's appropriate.

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/SerialController.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/SerialController.cs
@@ -48,7 +48,7 @@ public class SerialController : MonoBehaviour
              "newest messages from the port.")]
     public bool dropOldMessage;
 
-    public bool ignoreDroppedMessages;
+    public bool logDroppedMessages = true;
 
     [Tooltip("Read all unread messages in the queue during every Update loop. " +
              "Only used when \"Message Listener\" is provided.")]
@@ -82,7 +82,7 @@ public class SerialController : MonoBehaviour
                                              reconnectionDelay,
                                              maxUnreadMessages,
                                              dropOldMessage,
-                                             ignoreDroppedMessages,
+                                             logDroppedMessages,
                                              dtrEnable,
                                              rtsEnable);
         thread = new Thread(new ThreadStart(serialThread.RunForever));

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/SerialControllerCustomDelimiter.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/SerialControllerCustomDelimiter.cs
@@ -40,7 +40,7 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
              "newest messages from the port.")]
     public bool dropOldMessage;
 
-    public bool ignoreDroppedMessages;
+    public bool logDroppedMessages = true;
 
     [Tooltip("ASCII value of the character to use as separator. It marks the end of a " +
              "message and the beginning of the next.")]
@@ -67,7 +67,7 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
                                                        maxUnreadMessages,
                                                        separator,
                                                        dropOldMessage,
-                                                       ignoreDroppedMessages,
+                                                       logDroppedMessages,
                                                        dtrEnable,
                                                        rtsEnable);
         thread = new Thread(new ThreadStart(serialThread.RunForever));

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/SerialControllerCustomDelimiter.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/SerialControllerCustomDelimiter.cs
@@ -40,6 +40,8 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
              "newest messages from the port.")]
     public bool dropOldMessage;
 
+    public bool ignoreDroppedMessages;
+
     [Tooltip("ASCII value of the character to use as separator. It marks the end of a " +
              "message and the beginning of the next.")]
     public byte separator = 90;
@@ -65,6 +67,7 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
                                                        maxUnreadMessages,
                                                        separator,
                                                        dropOldMessage,
+                                                       ignoreDroppedMessages,
                                                        dtrEnable,
                                                        rtsEnable);
         thread = new Thread(new ThreadStart(serialThread.RunForever));
@@ -131,6 +134,10 @@ public class SerialControllerCustomDelimiter : MonoBehaviour
         return (byte[]) serialThread.ReadMessage();
     }
 
+    public void ClearQueue()
+    {
+        serialThread.ClearQueue();
+    }
     // ------------------------------------------------------------------------
     // Puts a message in the outgoing queue. The thread object will send the
     // message to the serial device when it considers it's appropriate.

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/AbstractSerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/AbstractSerialThread.cs
@@ -56,7 +56,7 @@ public abstract class AbstractSerialThread
     // When the queue is full, prefer dropping the message in the queue instead of the new message
     private bool dropOldMessage;
 
-    private bool ignoreDroppedMessages;
+    private bool logDroppedMessages;
 
     private bool dtrEnable = false;
     private bool rtsEnable = false;
@@ -76,7 +76,7 @@ public abstract class AbstractSerialThread
                                 int maxUnreadMessages,
                                 bool enqueueStatusMessages,
                                 bool dropOldMessage,
-                                bool ignoreDroppedMessages,
+                                bool logDroppedMessages,
                                 bool dtrEnable,
                                 bool rtsEnable)
     {
@@ -86,7 +86,7 @@ public abstract class AbstractSerialThread
         this.maxUnreadMessages = maxUnreadMessages;
         this.enqueueStatusMessages = enqueueStatusMessages;
         this.dropOldMessage = dropOldMessage;
-        this.ignoreDroppedMessages = ignoreDroppedMessages;
+        this.logDroppedMessages = logDroppedMessages;
         this.dtrEnable = dtrEnable;
         this.rtsEnable = rtsEnable;
 
@@ -107,8 +107,8 @@ public abstract class AbstractSerialThread
 
     public void ClearQueue()
     {
-        inputQueue = new Queue();
-        outputQueue = new Queue();
+        inputQueue.Clear();
+        outputQueue.Clear();
     }
 
     // ------------------------------------------------------------------------
@@ -301,7 +301,7 @@ public abstract class AbstractSerialThread
                     {
                         droppedMessage = inputMessage;
                     }
-                    if (!ignoreDroppedMessages) Debug.LogWarning("Queue is full. Dropping message: " + droppedMessage);
+                    if (logDroppedMessages) Debug.LogWarning("Queue is full. Dropping message: " + droppedMessage);
                 }
             }
         }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/AbstractSerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/AbstractSerialThread.cs
@@ -56,6 +56,8 @@ public abstract class AbstractSerialThread
     // When the queue is full, prefer dropping the message in the queue instead of the new message
     private bool dropOldMessage;
 
+    private bool ignoreDroppedMessages;
+
     private bool dtrEnable = false;
     private bool rtsEnable = false;
 
@@ -74,6 +76,7 @@ public abstract class AbstractSerialThread
                                 int maxUnreadMessages,
                                 bool enqueueStatusMessages,
                                 bool dropOldMessage,
+                                bool ignoreDroppedMessages,
                                 bool dtrEnable,
                                 bool rtsEnable)
     {
@@ -83,6 +86,7 @@ public abstract class AbstractSerialThread
         this.maxUnreadMessages = maxUnreadMessages;
         this.enqueueStatusMessages = enqueueStatusMessages;
         this.dropOldMessage = dropOldMessage;
+        this.ignoreDroppedMessages = ignoreDroppedMessages;
         this.dtrEnable = dtrEnable;
         this.rtsEnable = rtsEnable;
 
@@ -99,6 +103,12 @@ public abstract class AbstractSerialThread
         {
             stopRequested = true;
         }
+    }
+
+    public void ClearQueue()
+    {
+        inputQueue = new Queue();
+        outputQueue = new Queue();
     }
 
     // ------------------------------------------------------------------------
@@ -291,7 +301,7 @@ public abstract class AbstractSerialThread
                     {
                         droppedMessage = inputMessage;
                     }
-                    Debug.LogWarning("Queue is full. Dropping message: " + droppedMessage);
+                    if (!ignoreDroppedMessages) Debug.LogWarning("Queue is full. Dropping message: " + droppedMessage);
                 }
             }
         }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThread.cs
@@ -27,9 +27,10 @@ public class SerialThread : SerialThreadLines
                         int delayBeforeReconnecting,
                         int maxUnreadMessages,
                         bool dropOldMessage,
+                        bool ignoreDroppedMessages,
                         bool dtrEnable,
                         bool rtsEnable)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, dropOldMessage, dtrEnable, rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, dropOldMessage, ignoreDroppedMessages, dtrEnable, rtsEnable)
     {
     }
 }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThread.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThread.cs
@@ -27,10 +27,10 @@ public class SerialThread : SerialThreadLines
                         int delayBeforeReconnecting,
                         int maxUnreadMessages,
                         bool dropOldMessage,
-                        bool ignoreDroppedMessages,
+                        bool logDroppedMessages,
                         bool dtrEnable,
                         bool rtsEnable)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, dropOldMessage, ignoreDroppedMessages, dtrEnable, rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, dropOldMessage, logDroppedMessages, dtrEnable, rtsEnable)
     {
     }
 }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadCustomDelimiter.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadCustomDelimiter.cs
@@ -33,10 +33,10 @@ public class SerialThreadBinaryDelimited : AbstractSerialThread
                                        int maxUnreadMessages,
                                        byte separator,
                                        bool dropOldMessage,
-                                       bool ignoreDroppedMessages,
+                                       bool logDroppedMessages,
                                        bool dtrEnable,
                                        bool rtsEnable)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, false, dropOldMessage, ignoreDroppedMessages, dtrEnable, rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, false, dropOldMessage, logDroppedMessages, dtrEnable, rtsEnable)
     {
         this.separator = separator;
     }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadCustomDelimiter.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadCustomDelimiter.cs
@@ -33,9 +33,10 @@ public class SerialThreadBinaryDelimited : AbstractSerialThread
                                        int maxUnreadMessages,
                                        byte separator,
                                        bool dropOldMessage,
+                                       bool ignoreDroppedMessages,
                                        bool dtrEnable,
                                        bool rtsEnable)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, false, dropOldMessage, dtrEnable, rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, false, dropOldMessage, ignoreDroppedMessages, dtrEnable, rtsEnable)
     {
         this.separator = separator;
     }

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadLines.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadLines.cs
@@ -26,9 +26,10 @@ public class SerialThreadLines : AbstractSerialThread
                              int delayBeforeReconnecting,
                              int maxUnreadMessages,
                              bool dropOldMessage,
+                             bool ignoreDroppedMessages,
                              bool dtrEnable,
                              bool rtsEnable)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, true, dropOldMessage, dtrEnable, rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, true, dropOldMessage, ignoreDroppedMessages, dtrEnable, rtsEnable)
     {
     }
 

--- a/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadLines.cs
+++ b/UnityProject/Assets/Ardity/Scripts/Runtime/Threads/SerialThreadLines.cs
@@ -26,10 +26,10 @@ public class SerialThreadLines : AbstractSerialThread
                              int delayBeforeReconnecting,
                              int maxUnreadMessages,
                              bool dropOldMessage,
-                             bool ignoreDroppedMessages,
+                             bool logDroppedMessages,
                              bool dtrEnable,
                              bool rtsEnable)
-        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, true, dropOldMessage, ignoreDroppedMessages, dtrEnable, rtsEnable)
+        : base(portName, baudRate, delayBeforeReconnecting, maxUnreadMessages, true, dropOldMessage, logDroppedMessages, dtrEnable, rtsEnable)
     {
     }
 


### PR DESCRIPTION
My use case for this package requires sending a lot of messages, and having a lot of messages in the input queue makes unity freeze before quitting the application because it's processing all unsent messages instead of just dropping them

So my solution is to execute queue clear as a teardown function. That way, when SerialThread.RequestStop() is executed, the input queue will be empty and there will be no messages to process

Also I need to drop a lot of messages in order to reduce input latency, so I added a way to disable the dropped message warning